### PR TITLE
Fix `Eq` / `Eq1` instances for compose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,11 @@ install:
   - chmod a+x $HOME/purescript
   - npm install -g bower
   - npm install
-  - bower install
+  - bower install --production
 script:
   - npm run -s build
+  - bower install
+  - npm run -s test
 after_success:
 - >-
   test $TRAVIS_TAG &&

--- a/bower.json
+++ b/bower.json
@@ -27,5 +27,8 @@
     "purescript-prelude": "^4.0.0",
     "purescript-tuples": "^5.0.0",
     "purescript-unsafe-coerce": "^4.0.0"
+  },
+  "devDependencies": {
+    "purescript-assert": "^4.0.0"
   }
 }

--- a/src/Data/Functor/Compose.purs
+++ b/src/Data/Functor/Compose.purs
@@ -27,17 +27,17 @@ bihoistCompose natF natG (Compose fga) = Compose (natF (map natG fga))
 
 derive instance newtypeCompose :: Newtype (Compose f g a) _
 
+instance eqCompose :: (Eq1 f, Eq1 g, Eq a) => Eq (Compose f g a) where
+  eq (Compose fga1) (Compose fga2) =
+    eq1 (hoistLiftApp fga1) (hoistLiftApp fga2)
+
 derive instance eq1Compose :: (Eq1 f, Eq1 g) => Eq1 (Compose f g)
 
-instance eqCompose :: (Eq1 f, Eq1 g, Eq a) => Eq (Compose f g a) where
-  eq = eq1
-
-instance ord1Compose :: (Ord1 f, Ord1 g) => Ord1 (Compose f g) where
-  compare1 (Compose fga1) (Compose fga2) =
+instance ordCompose :: (Ord1 f, Ord1 g, Ord a) => Ord (Compose f g a) where
+  compare (Compose fga1) (Compose fga2) =
     compare1 (hoistLiftApp fga1) (hoistLiftApp fga2)
 
-instance ordCompose :: (Ord1 f, Ord1 g, Ord a) => Ord (Compose f g a) where
-  compare = compare1
+derive instance ord1Compose :: (Ord1 f, Ord1 g) => Ord1 (Compose f g)
 
 instance showCompose :: Show (f (g a)) => Show (Compose f g a) where
   show (Compose fga) = "(Compose " <> show fga <> ")"

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,0 +1,20 @@
+module Test.Main where
+
+import Prelude
+
+import Data.Functor.Compose (Compose(..))
+import Data.Identity (Identity(..))
+import Data.Maybe (Maybe(..))
+import Effect (Effect)
+import Test.Assert (assertEqual)
+
+main :: Effect Unit
+main = do
+  assertEqual
+    { expected: Compose (Identity (Just true))
+    , actual: Compose (Identity (Just true))
+    }
+  assertEqual
+    { expected: Compose (Identity (Just true)) > Compose (Identity (Just false))
+    , actual: true
+    }


### PR DESCRIPTION
Currently trying to `eq` `Compose` results in a stack overflow as we have `eq = eq1` and `eq1 = eq` as the definitions.