### PR TITLE
Reorder Inject instances to allow inj :: f ~> f

### DIFF
--- a/src/Data/Functor/Coproduct/Inject.purs
+++ b/src/Data/Functor/Coproduct/Inject.purs
@@ -10,14 +10,14 @@ class Inject f g where
   inj :: forall a. f a -> g a
   prj :: forall a. g a -> Maybe (f a)
 
-instance injectLeft :: Inject f (Coproduct f g) where
+instance injectReflexive :: Inject f f where
+  inj = identity
+  prj = Just
+
+else instance injectLeft :: Inject f (Coproduct f g) where
   inj = Coproduct <<< Left
   prj = coproduct Just (const Nothing)
 
 else instance injectRight :: Inject f g => Inject f (Coproduct h g) where
   inj = Coproduct <<< Right <<< inj
   prj = coproduct (const Nothing) prj
-
-else instance injectReflexive :: Inject f f where
-  inj = identity
-  prj = Just

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,7 +2,10 @@ module Test.Main where
 
 import Prelude
 
+import Data.Const (Const)
 import Data.Functor.Compose (Compose(..))
+import Data.Functor.Coproduct (Coproduct, left, right)
+import Data.Functor.Coproduct.Inject (inj)
 import Data.Identity (Identity(..))
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
@@ -10,6 +13,11 @@ import Test.Assert (assertEqual)
 
 main :: Effect Unit
 main = do
+  testComposeOrdering
+  testInjections
+
+testComposeOrdering :: Effect Unit
+testComposeOrdering = do
   assertEqual
     { expected: Compose (Identity (Just true))
     , actual: Compose (Identity (Just true))
@@ -17,4 +25,19 @@ main = do
   assertEqual
     { expected: Compose (Identity (Just true)) > Compose (Identity (Just false))
     , actual: true
+    }
+
+testInjections :: Effect Unit
+testInjections = do
+  assertEqual
+    { expected: Identity unit
+    , actual: inj (Identity unit)
+    }
+  assertEqual
+    { expected: left (Identity unit) :: Coproduct Identity (Const Void) Unit
+    , actual: inj (Identity unit)
+    }
+  assertEqual
+    { expected: right (Identity unit) :: Coproduct (Const Void) Identity Unit
+    , actual: inj (Identity unit)
     }


### PR DESCRIPTION
Same as with the `Either` case :wink: