### PR TITLE
bring App documentation in line with Haskell Data.Monoid.Ap 

### DIFF
--- a/src/Data/Functor/App.purs
+++ b/src/Data/Functor/App.purs
@@ -20,6 +20,7 @@ import Data.Traversable (class Traversable)
 import Data.TraversableWithIndex (class TraversableWithIndex)
 import Unsafe.Coerce (unsafeCoerce)
 
+-- | `App` witnesses the lifting of a `Monoid` into an `Applicative` pointwise.
 newtype App f a = App (f a)
 
 hoistApp :: forall f g. (f ~> g) -> App f ~> App g


### PR DESCRIPTION
This will make the usage of the App newtype clearer as well as more searchable.