### PR TITLE
Add Category instance for Flip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Breaking changes:
 
 New features:
 
+- `Semigroupoid` and `Category` instances for `Flip` (#33)
+
 Bugfixes:
 
 Other improvements:

--- a/src/Data/Functor/Flip.purs
+++ b/src/Data/Functor/Flip.purs
@@ -37,10 +37,8 @@ instance biapplicativeFlip :: Biapplicative p => Biapplicative (Flip p) where
 instance contravariantFlip :: Profunctor p => Contravariant (Flip p b) where
   cmap f (Flip a) = Flip (lcmap f a)
 
-instance semigroupoidFlip :: Semigroupoid p => Semigroupoid (Flip p)
-  where
+instance semigroupoidFlip :: Semigroupoid p => Semigroupoid (Flip p) where
   compose (Flip a) (Flip b) = Flip $ compose b a
 
-instance categoryFlip :: Category p => Category (Flip p)
-  where
+instance categoryFlip :: Category p => Category (Flip p) where
   identity = Flip identity

--- a/src/Data/Functor/Flip.purs
+++ b/src/Data/Functor/Flip.purs
@@ -36,3 +36,11 @@ instance biapplicativeFlip :: Biapplicative p => Biapplicative (Flip p) where
 
 instance contravariantFlip :: Profunctor p => Contravariant (Flip p b) where
   cmap f (Flip a) = Flip (lcmap f a)
+
+instance semigroupoidFlip :: Semigroupoid p => Semigroupoid (Flip p)
+  where
+  compose (Flip a) (Flip b) = Flip $ compose b a
+
+instance categoryFlip :: Category p => Category (Flip p)
+  where
+  identity = Flip identity


### PR DESCRIPTION
**Description of the change**

If `p :: K -> K -> Type` represents the hom-constructor of some category, then `Flip p :: K -> K -> Type` represents the hom-constructor of its dual category. This category has the same objects as `p`, but the set of arrows from some object `A` to some object `B` is taken to be the set of arrows from the object `B` to the object `A` in the original category.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- ~[ ] Updated or added relevant documentation~
- ~[ ] Added a test for the contribution (if applicable)~